### PR TITLE
feat(offchain-manager): add support for new chains and enhance addres…

### DIFF
--- a/changelog/addresses-changelog.md
+++ b/changelog/addresses-changelog.md
@@ -1,53 +1,12 @@
 # Changelog
 
-All notable changes to the `@thenamespace/offchain-manager` package will be documented in this file.
+All notable changes to the `@thenamespace/addresses` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - 2025-08-05
-
-### Documentation
-
-- **Enhanced README.md**:
-  - Added Supported Chains section with quick reference to available blockchain networks
-  - Added Error Handling section with try-catch examples and specific error classes
-
-## [1.0.0] - 2025-08-05
+## [1.0.15] - 2025-07-25
 
 ### Changed
 
-- **BREAKING**: Package name changed from `@namespacesdk/offchain-manager` to `@thenamespace/offchain-manager`
-- Enhanced package description for better discoverability
-- Updated repository information and added homepage
-- Added comprehensive keywords (ens, ethereum, subnames, domains, web3, sdk, etc.)
-- Added engines specification requiring Node.js >=16.0.0
-- Added publishConfig for public access
-
-### Documentation
-
-- **Enhanced README.md**:
-  - Added comprehensive API key types documentation (Address-based vs Domain-based)
-  - Updated all code examples with new package name
-  - Improved environment setup instructions
-  - Added mixed usage examples for API keys
-  - Updated Namespace Dev Portal section with API key type explanations
-- **Improved TESTING.md**:
-  - Updated title and package references
-  - Fixed environment configuration examples
-  - Updated CI/CD workflow examples
-  - Improved code formatting and consistency
-
-### Package Improvements
-
-- Repository field with proper GitHub organization link
-- Homepage field pointing to namespace.ninja
-- Bugs field for issue tracking
-- PublishConfig for NPM organization publishing
-- Enhanced metadata for better package discovery
-
-### Fixed
-
-- All import statements updated to use new package name
-- Documentation consistency across all files
-- Package.json validation and best practices compliance
+- **BREAKING**: SDK renamed to `@thenamespace/addresses`.

--- a/changelog/offchain-manager-changelog.md
+++ b/changelog/offchain-manager-changelog.md
@@ -1,4 +1,86 @@
-1.0.2 - Enhanced README.md:   - Added Supported Chains section with quick reference to available blockchain networks   - Added Error Handling section with try-catch examples and specific error classes
+# Changelog
 
-1.0.1 - # Changelog  All notable changes to the `@thenamespace/offchain-manager` package will be documented in this file.  The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  ## [1.0.0] - 2025-08-05  ### Changed  - **BREAKING**: Package name changed from `@namespacesdk/offchain-manager` to `@thenamespace/offchain-manager` - Enhanced package description for better discoverability - Updated repository information and added homepage - Added comprehensive keywords (ens, ethereum, subnames, domains, web3, sdk, etc.) - Added engines specification requiring Node.js >=16.0.0 - Added publishConfig for public access  ### Documentation  - **Enhanced README.md**:   - Added comprehensive API key types documentation (Address-based vs Domain-based)   - Updated all code examples with new package name   - Improved environment setup instructions   - Added mixed usage examples for API keys   - Updated Namespace Dev Portal section with API key type explanations - **Improved TESTING.md**:   - Updated title and package references   - Fixed environment configuration examples   - Updated CI/CD workflow examples   - Improved code formatting and consistency  ### Package Improvements  - Repository field with proper GitHub organization link - Homepage field pointing to namespace.ninja - Bugs field for issue tracking - PublishConfig for NPM organization publishing - Enhanced metadata for better package discovery  ### Fixed  - All import statements updated to use new package name - Documentation consistency across all files - Package.json validation and best practices compliance
+All notable changes to the `@thenamespace/offchain-manager` package will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.3] - 2025-08-19
+
+### Added
+
+- **New Blockchain Support**: Added support for 7 new blockchain networks:
+  - Unichain
+  - Berachain
+  - WorldChain
+  - Zora
+  - Celo
+  - Aptos
+  - Algorand
+
+### Enhanced
+
+- **Improved Address Validation**:
+  - Enhanced Starknet address validation to support variable-length hex addresses (1-64 characters)
+  - Improved Bitcoin address validation to support Legacy (P2PKH), Script (P2SH), Bech32 (P2WPKH/P2WSH), and Taproot (P2TR) formats
+  - Updated Cosmos address validation to use proper bech32 format with 'cosmos1' prefix
+  - Enhanced NEAR address validation to support both implicit accounts (64 hex chars) and named accounts (.near)
+  - Improved Sui address validation to support variable-length hex addresses (1-64 characters)
+  - Added Aptos address validation with variable-length hex support
+  - Added Algorand address validation using Base32 format (58 characters)
+
+### Testing
+
+- **Comprehensive Test Coverage**:
+  - Added validation tests for all new blockchain chains
+  - Enhanced Bitcoin address validation tests with multiple format support
+  - Added Starknet address validation tests for both full and shortened addresses
+  - Added Cosmos, NEAR, Sui, Aptos, and Algorand address validation tests
+  - Added EVM-compatible chain address validation tests
+
+## [1.0.2] - 2025-08-05
+
+### Documentation
+
+- **Enhanced README.md**:
+  - Added Supported Chains section with quick reference to available blockchain networks
+  - Added Error Handling section with try-catch examples and specific error classes
+
+## [1.0.0] - 2025-08-05
+
+### Changed
+
+- **BREAKING**: Package name changed from `@namespacesdk/offchain-manager` to `@thenamespace/offchain-manager`
+- Enhanced package description for better discoverability
+- Updated repository information and added homepage
+- Added comprehensive keywords (ens, ethereum, subnames, domains, web3, sdk, etc.)
+- Added engines specification requiring Node.js >=16.0.0
+- Added publishConfig for public access
+
+### Documentation
+
+- **Enhanced README.md**:
+  - Added comprehensive API key types documentation (Address-based vs Domain-based)
+  - Updated all code examples with new package name
+  - Improved environment setup instructions
+  - Added mixed usage examples for API keys
+  - Updated Namespace Dev Portal section with API key type explanations
+- **Improved TESTING.md**:
+  - Updated title and package references
+  - Fixed environment configuration examples
+  - Updated CI/CD workflow examples
+  - Improved code formatting and consistency
+
+### Package Improvements
+
+- Repository field with proper GitHub organization link
+- Homepage field pointing to namespace.ninja
+- Bugs field for issue tracking
+- PublishConfig for NPM organization publishing
+- Enhanced metadata for better package discovery
+
+### Fixed
+
+- All import statements updated to use new package name
+- Documentation consistency across all files
+- Package.json validation and best practices compliance

--- a/packages/offchain-manager/src/dto/chains.ts
+++ b/packages/offchain-manager/src/dto/chains.ts
@@ -48,6 +48,20 @@ export enum ChainName {
   Starknet = "starknet",
   /** Sui Network */
   Sui = "sui",
+  /** Unichain */
+  Unichain = "unichain",
+  /** Berachain */
+  Berachain = "berachain",
+  /** WorldChain */
+  WorldChain = "world_chain",
+  /** Zora */
+  Zora = "zora",
+  /** Celo */
+  Celo = "celo",
+  /** Aptos */
+  Aptos = "aptos",
+  /** Algorand */
+  Algorand = "algorand",
 }
 
 /**
@@ -131,7 +145,35 @@ export const chainMetadata: Record<ChainName, ChainMetadata> = {
   },
   sui: {
     label: "Sui",
-    coin: 784,
+    coin: 101,
+  },
+  unichain: {
+    label: "Unichain",
+    coin: 130,
+  },
+  berachain: {
+    label: "Berachain",
+    coin: 80094,
+  },
+  world_chain: {
+    label: "WorldChain",
+    coin: 480,
+  },
+  zora: {
+    label: "Zora",
+    coin: 7777777,
+  },
+  celo: {
+    label: "Celo",
+    coin: 42220,
+  },
+  aptos: {
+    label: "Aptos",
+    coin: 22,
+  },
+  algorand: {
+    label: "Algorand",
+    coin: 8,
   },
 };
 

--- a/packages/offchain-manager/src/offchain-client/validation.ts
+++ b/packages/offchain-manager/src/offchain-client/validation.ts
@@ -170,47 +170,80 @@ export const validateAddress = (address: string, chain: ChainName): void => {
         case ChainName.Zksync:
         case ChainName.Linea:
         case ChainName.Scroll:
-        case ChainName.Starknet:
-            // Ethereum-style addresses
+        case ChainName.Unichain:
+        case ChainName.Berachain:
+        case ChainName.WorldChain:
+        case ChainName.Zora:
+        case ChainName.Celo:
+            // Ethereum-style addresses (EVM chains)
             if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
                 throw new ValidationError(`Invalid Ethereum-style address: ${address}`);
             }
             break;
+        
+        case ChainName.Starknet:
+            // Starknet addresses are up to 64 hex characters (leading zeros can be omitted)
+            if (!/^0x[a-fA-F0-9]{1,64}$/.test(address)) {
+                throw new ValidationError(`Invalid Starknet address: ${address}`);
+            }
+            break;
+        
         case ChainName.Solana:
             // Solana addresses are base58 encoded, typically 32-44 characters
             if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)) {
                 throw new ValidationError(`Invalid Solana address: ${address}`);
             }
             break;
+        
         case ChainName.Bitcoin:
-            // Bitcoin addresses (simplified validation)
-            if (!/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/.test(address)) {
+            // Bitcoin addresses - supports Legacy (P2PKH), Script (P2SH), Bech32 (P2WPKH/P2WSH), and Taproot (P2TR)
+            const bitcoinRegex = /^([13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[a-z0-9]{39,59})$/;
+            if (!bitcoinRegex.test(address)) {
                 throw new ValidationError(`Invalid Bitcoin address: ${address}`);
             }
             break;
+        
         case ChainName.Cosmos:
-            // Cosmos addresses start with 'cosmos'
-            if (!/^cosmos[a-zA-Z0-9]{38}$/.test(address)) {
+            // Cosmos addresses use bech32 format with 'cosmos' prefix
+            if (!/^cosmos1[a-z0-9]{38}$/.test(address)) {
                 throw new ValidationError(`Invalid Cosmos address: ${address}`);
             }
             break;
+        
         case ChainName.Near:
-            // NEAR addresses end with .near
-            if (!/^[a-z0-9._-]+\.near$/.test(address)) {
+            // NEAR addresses: either implicit (64 hex chars) or named accounts ending with .near
+            const nearImplicit = /^[a-f0-9]{64}$/;
+            const nearNamed = /^[a-z0-9._-]+\.near$/;
+            if (!nearImplicit.test(address) && !nearNamed.test(address)) {
                 throw new ValidationError(`Invalid NEAR address: ${address}`);
             }
             break;
+        
         case ChainName.Sui:
-            // Sui addresses are 64 character hex strings
-            if (!/^0x[a-fA-F0-9]{64}$/.test(address)) {
+            // Sui addresses are up to 64 hex characters (leading zeros can be omitted)
+            if (!/^0x[a-fA-F0-9]{1,64}$/.test(address)) {
                 throw new ValidationError(`Invalid Sui address: ${address}`);
             }
             break;
+        
+        case ChainName.Aptos:
+            // Aptos addresses are up to 64 hex characters (leading zeros can be omitted)
+            if (!/^0x[a-fA-F0-9]{1,64}$/.test(address)) {
+                throw new ValidationError(`Invalid Aptos address: ${address}`);
+            }
+            break;
+        
+        case ChainName.Algorand:
+            // Algorand addresses are 58-character Base32 strings (A-Z, 2-7)
+            if (!/^[A-Z2-7]{58}$/.test(address)) {
+                throw new ValidationError(`Invalid Algorand address: ${address}`);
+            }
+            break;
+        
         default:
             throw new ValidationError(`Unsupported chain: ${chain}`);
     }
 };
-
 /**
  * Validates that an API key appears to be in the correct format.
  * This performs basic sanity checks but doesn't verify the key with the server.

--- a/packages/offchain-manager/tests/validation.test.ts
+++ b/packages/offchain-manager/tests/validation.test.ts
@@ -60,9 +60,80 @@ describe('Validation Functions', () => {
         });
 
         it('should validate Bitcoin addresses', () => {
-            const validBtcAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
-            expect(() => validateAddress(validBtcAddress, ChainName.Bitcoin)).not.toThrow();
+            // Legacy P2PKH addresses
+            const validBtcLegacy = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+            expect(() => validateAddress(validBtcLegacy, ChainName.Bitcoin)).not.toThrow();
+            
+            // P2SH addresses
+            const validBtcP2SH = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+            expect(() => validateAddress(validBtcP2SH, ChainName.Bitcoin)).not.toThrow();
+            
+            // Bech32 addresses
+            const validBtcBech32 = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+            expect(() => validateAddress(validBtcBech32, ChainName.Bitcoin)).not.toThrow();
         });
+
+        it('should validate Starknet addresses', () => {
+            // Full 64-character address
+            const validStarknetFull = '0x1234567890123456789012345678901234567890123456789012345678901234';
+            expect(() => validateAddress(validStarknetFull, ChainName.Starknet)).not.toThrow();
+            
+            // Shortened address (leading zeros omitted)
+            const validStarknetShort = '0x123456789012345678901234567890123456789012345678901234567890123';
+            expect(() => validateAddress(validStarknetShort, ChainName.Starknet)).not.toThrow();
+        });
+
+        it('should validate Cosmos addresses', () => {
+            const validCosmosAddress = 'cosmos1edr3tkta8y3pqz9py3dpwhmhsvuzr3dqnl2wdm';
+            expect(() => validateAddress(validCosmosAddress, ChainName.Cosmos)).not.toThrow();
+        });
+
+        it('should validate NEAR addresses', () => {
+            // Named account
+            const validNearNamed = 'alice.near';
+            expect(() => validateAddress(validNearNamed, ChainName.Near)).not.toThrow();
+            
+            // Implicit account (64 hex characters)
+            const validNearImplicit = '1234567890123456789012345678901234567890123456789012345678901234';
+            expect(() => validateAddress(validNearImplicit, ChainName.Near)).not.toThrow();
+        });
+
+        it('should validate Sui addresses', () => {
+            // Full 64-character address
+            const validSuiFull = '0x556a3c6c150709c0a8486e3eb002ea8118ba79bdf349e710dc3bb85901f797c3';
+            expect(() => validateAddress(validSuiFull, ChainName.Sui)).not.toThrow();
+            
+            // Shortened address (leading zeros omitted)
+            const validSuiShort = '0x123456789012345678901234567890123456789012345678901234567890123';
+            expect(() => validateAddress(validSuiShort, ChainName.Sui)).not.toThrow();
+        });
+
+        it('should validate Aptos addresses', () => {
+            // Full 64-character address
+            const validAptosFull = '0x1234567890123456789012345678901234567890123456789012345678901234';
+            expect(() => validateAddress(validAptosFull, ChainName.Aptos)).not.toThrow();
+            
+            // Shortened address (leading zeros omitted)
+            const validAptosShort = '0x123456789012345678901234567890123456789012345678901234567890123';
+            expect(() => validateAddress(validAptosShort, ChainName.Aptos)).not.toThrow();
+        });
+
+        it('should validate Algorand addresses', () => {
+            const validAlgorandAddress = 'L4BTUQ5FVCKHSQYYXOG2HPH3EKK4VXZSXK7FQBDWPRR3YJ5RQ6DVSBARDQ';
+            expect(() => validateAddress(validAlgorandAddress, ChainName.Algorand)).not.toThrow();
+        });
+
+        it('should validate EVM-compatible chain addresses', () => {
+            const validEVMAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+            
+            // Test all EVM-compatible chains
+            expect(() => validateAddress(validEVMAddress, ChainName.Unichain)).not.toThrow();
+            expect(() => validateAddress(validEVMAddress, ChainName.Berachain)).not.toThrow();
+            expect(() => validateAddress(validEVMAddress, ChainName.WorldChain)).not.toThrow();
+            expect(() => validateAddress(validEVMAddress, ChainName.Zora)).not.toThrow();
+            expect(() => validateAddress(validEVMAddress, ChainName.Celo)).not.toThrow();
+        });
+
     });
 
     describe('validateApiKey', () => {


### PR DESCRIPTION

### Added

- **New Blockchain Support**: Added support for 7 new blockchain networks:
  - Unichain
  - Berachain
  - WorldChain
  - Zora
  - Celo
  - Aptos
  - Algorand

### Enhanced

- **Improved Address Validation**:
  - Enhanced Starknet address validation to support variable-length hex addresses (1-64 characters)
  - Improved Bitcoin address validation to support Legacy (P2PKH), Script (P2SH), Bech32 (P2WPKH/P2WSH), and Taproot (P2TR) formats
  - Updated Cosmos address validation to use proper bech32 format with 'cosmos1' prefix
  - Enhanced NEAR address validation to support both implicit accounts (64 hex chars) and named accounts (.near)
  - Improved Sui address validation to support variable-length hex addresses (1-64 characters)
  - Added Aptos address validation with variable-length hex support
  - Added Algorand address validation using Base32 format (58 characters)

### Testing

- **Comprehensive Test Coverage**:
  - Added validation tests for all new blockchain chains
  - Enhanced Bitcoin address validation tests with multiple format support
  - Added Starknet address validation tests for both full and shortened addresses
  - Added Cosmos, NEAR, Sui, Aptos, and Algorand address validation tests
  - Added EVM-compatible chain address validation tests
