### PR TITLE
feat(offchain-manager): add Polkadot and Vara Network chain support

### DIFF
--- a/packages/offchain-manager/src/dto/chains.ts
+++ b/packages/offchain-manager/src/dto/chains.ts
@@ -68,6 +68,10 @@ export enum ChainName {
   Monad = "monad",
   /** Push Chain */
   Push = "push",
+  /** Polkadot */
+  Polkadot = "dot",
+  /** Vara Network */
+  Vara = "vara",
 }
 
 /**
@@ -213,6 +217,14 @@ export const chainMetadata: Record<ChainName, ChainMetadata> = {
     label: "Push Chain",
     coin: 42101,
     evm: true,
+  },
+  dot: {
+    label: "Polkadot",
+    coin: 354,
+  },
+  vara: {
+    label: "Vara",
+    coin: 913,
   },
 };
 

--- a/packages/offchain-manager/src/offchain-client/validation.ts
+++ b/packages/offchain-manager/src/offchain-client/validation.ts
@@ -1,6 +1,18 @@
 import { ValidationError } from './errors';
 import { ChainName } from '../dto';
 
+// Validates a Substrate SS58 address by leading characters, length range, and base58 charset.
+const isValidSs58 = (
+    value: string,
+    leadingChars: string,
+    minLen: number,
+    maxLen: number = minLen,
+): boolean => {
+    if (value.length < minLen || value.length > maxLen) return false;
+    if (!value.startsWith(leadingChars)) return false;
+    return /^[1-9A-HJ-NP-Za-km-z]+$/.test(value);
+};
+
 /**
  * Validates that a string is a properly formatted ENS domain name.
  * ENS supports many TLDs including .eth, .com, .art, .xyz, and others through ENS import.
@@ -146,7 +158,13 @@ export const validateSubname = (subname: string): void => {
  * 
  * // NEAR addresses (.near suffix)
  * validateAddress('alice.near', ChainName.Near); // ✅
- * 
+ *
+ * // Polkadot addresses (SS58, prefix 0 → 47-48 chars starting with "1")
+ * validateAddress('15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5', ChainName.Polkadot); // ✅
+ *
+ * // Vara Network addresses (SS58, prefix 137 → 49 chars starting with "kG")
+ * validateAddress('kGkLEU3e3XXkJp2WK4eNpVmSab5xUNL9QtmLPh8QfCL2EgotW', ChainName.Vara); // ✅
+ *
  * // Invalid examples
  * validateAddress('invalid', ChainName.Ethereum); // ❌ Throws ValidationError
  * validateAddress('0x123', ChainName.Ethereum); // ❌ Throws ValidationError (too short)
@@ -242,7 +260,21 @@ export const validateAddress = (address: string, chain: ChainName): void => {
                 throw new ValidationError(`Invalid Algorand address: ${address}`);
             }
             break;
-        
+
+        case ChainName.Polkadot:
+            // SS58 prefix 0 — addresses are 47-48 chars and start with "1"
+            if (!isValidSs58(address, '1', 47, 48)) {
+                throw new ValidationError(`Invalid Polkadot address: ${address}`);
+            }
+            break;
+
+        case ChainName.Vara:
+            // SS58 prefix 137 — addresses are 49 chars and always start with "kG"
+            if (!isValidSs58(address, 'kG', 49)) {
+                throw new ValidationError(`Invalid Vara address: ${address}`);
+            }
+            break;
+
         default:
             throw new ValidationError(`Unsupported chain: ${chain}`);
     }

--- a/packages/offchain-manager/tests/validation.test.ts
+++ b/packages/offchain-manager/tests/validation.test.ts
@@ -123,6 +123,42 @@ describe('Validation Functions', () => {
             expect(() => validateAddress(validAlgorandAddress, ChainName.Algorand)).not.toThrow();
         });
 
+        it('should validate Polkadot addresses', () => {
+            // SS58 prefix 0 — Polkadot addresses are 47-48 chars and start with "1"
+            // (computed via @polkadot/util-crypto encodeAddress(pubkey, 0))
+            const validDot1 = '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5';
+            const validDot2 = '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3';
+            expect(() => validateAddress(validDot1, ChainName.Polkadot)).not.toThrow();
+            expect(() => validateAddress(validDot2, ChainName.Polkadot)).not.toThrow();
+        });
+
+        it('should reject invalid Polkadot addresses', () => {
+            // Vara address (wrong leading "kG")
+            expect(() => validateAddress('kGkLEU3e3XXkJp2WK4eNpVmSab5xUNL9QtmLPh8QfCL2EgotW', ChainName.Polkadot)).toThrow(ValidationError);
+            // Too short
+            expect(() => validateAddress('1FRM', ChainName.Polkadot)).toThrow(ValidationError);
+            // EVM-style address rejected
+            expect(() => validateAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', ChainName.Polkadot)).toThrow(ValidationError);
+        });
+
+        it('should validate Vara Network addresses', () => {
+            // SS58 prefix 137 — Vara addresses always start with "kG" and are 49 chars long
+            // (computed via @polkadot/util-crypto encodeAddress(pubkey, 137))
+            const validVaraAddress = 'kGkLEU3e3XXkJp2WK4eNpVmSab5xUNL9QtmLPh8QfCL2EgotW';
+            expect(() => validateAddress(validVaraAddress, ChainName.Vara)).not.toThrow();
+            const anotherValidVara = 'kGfXzQ99jakxFMQEox9iQYQ6zfMkwScJTScuPLSovqxjPbkXW';
+            expect(() => validateAddress(anotherValidVara, ChainName.Vara)).not.toThrow();
+        });
+
+        it('should reject invalid Vara Network addresses', () => {
+            // Polkadot address (SS58 prefix 0, leading "1")
+            expect(() => validateAddress('15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5', ChainName.Vara)).toThrow(ValidationError);
+            // Too short
+            expect(() => validateAddress('kGfo5pfYwgDbm3yKBV4', ChainName.Vara)).toThrow(ValidationError);
+            // EVM-style address rejected
+            expect(() => validateAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', ChainName.Vara)).toThrow(ValidationError);
+        });
+
         it('should validate EVM-compatible chain addresses', () => {
             const validEVMAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
             


### PR DESCRIPTION
## Summary

- Adds **Polkadot** (`ChainName.Polkadot = "dot"`, coin 354) and **Vara Network** (`ChainName.Vara = "vara"`, coin 913) — two Substrate L1 chains, neither EVM-compatible.
- New entries in `ChainName` enum + `chainMetadata` (no `evm: true` flag — same shape as Cosmos / NEAR).
- New shared helper in `src/offchain-client/validation.ts`:
  ```ts
  isValidSs58(value, leadingChars, minLen, maxLen?)
  ```
  validates length range, leading characters, and base58 charset. Both Polkadot and Vara `case` arms in `validateAddress` route through it.
- JSDoc `@example` block updated with one Polkadot and one Vara sample.

References:
- SLIP-0044: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
- SS58 registry: https://github.com/paritytech/ss58-registry

## Test plan

Verified:
- [x] `pnpm tsc --noEmit` passes clean.
- [x] Four new test blocks in `tests/validation.test.ts` (positive + negative for each chain). Positive cases use real addresses computed via `@polkadot/util-crypto encodeAddress(pubkey, prefix)`. Negative tests cross-reject between the two chains (Polkadot validator rejects a Vara address and vice versa) plus reject EVM-style and truncated inputs.
- [x] Helper logic also verified against 7 cases in a standalone Node script.

Deferred:
- Could not run the SDK Jest suite (`pnpm test`) on the contributor machine — pre-existing `msw` ESM transform error in `tests/setup.ts:5`, reproducible on a clean checkout without my edits. CI / a fresh install should pick the new tests up; if the suite fails for an unrelated reason, the helper logic itself was verified manually as noted above.