### PR TITLE
fix(avatar): restore npm 11 lock integrity and add Claude skill

### DIFF
--- a/.claude/skills/avatar-sdk/SKILL.md
+++ b/.claude/skills/avatar-sdk/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: avatar-sdk
+description: Upload, update, and delete ENS avatar and header images with SIWE v4 authentication using the @thenamespace/avatar SDK. Use whenever working with ENS profile images, avatar/header uploads or deletes, SIWE (Sign In With Ethereum) signing flows, Viem/Ethers/wagmi wallet integration for image management, or the Namespace Metadata Service profile media routes — even if the user just says "upload a profile pic" or "set an ENS avatar".
+---
+
+# Namespace Avatar SDK (v2)
+
+This skill helps you work with the `@thenamespace/avatar` SDK to manage ENS
+avatar and header images. v2 adds **SIWE v4** (smart-contract wallet support),
+a **compact header route**, **automatic network/chain enforcement**, and a
+**normalized upload result** with a stable `url` field.
+
+## What the SDK does
+
+- **Upload / delete avatar and header images** for ENS subnames
+- **SIWE v4 authentication** — works for EOAs *and* deployed smart-contract
+  wallets. The SDK does **not** do client-side ERC-6492 handling; it passes the
+  signature straight through to the Metadata Service, which verifies it.
+- **Direct wallet integration** — pass a Viem `WalletClient`, Ethers
+  `Wallet`/`Signer`, or any `WalletProvider` directly. No adapters to write.
+- **Automatic + manual flows** — provider signs for you, or you sign yourself.
+- **Network enforcement** — before any automatic op it checks the wallet's chain
+  matches the configured network and switches it if the wallet supports that.
+- **Progress tracking** and **file validation** (size + format).
+
+## Installation
+
+```bash
+npm install @thenamespace/avatar
+# peer: viem or ethers (only if you use one as your provider)
+```
+
+## Quick start (automatic flow)
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { createWalletClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+const walletClient = createWalletClient({
+  // Load secrets from your environment or secret manager; never hard-code them.
+  account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+  chain: mainnet,
+  transport: http(),
+});
+
+const client = createAvatarClient({
+  network: 'mainnet',        // 'mainnet' (default) | 'sepolia'
+  domain: 'yourapp.com',     // required for SIWE
+  provider: walletClient,    // viem / ethers / WalletProvider — passed directly
+});
+
+const result = await client.uploadAvatar({
+  subname: 'alice.namespace.eth',
+  file: avatarFile,          // File (browser) or Buffer (Node)
+  onProgress: (p) => console.log(`Upload: ${p.toFixed(0)}%`),
+});
+
+console.log(result.url);     // stable public URL
+```
+
+The automatic flow uses the `domain` from initialization — you don't pass it
+per-call. Before signing, the SDK compares `provider.getChainId()` with the
+configured network (mainnet = `1`, sepolia = `11155111`) and calls
+`provider.switchChain()` if available; if the wallet can't be switched it throws
+`PROVIDER_CHAIN_MISMATCH` *before* requesting a nonce or signing.
+
+## Core API
+
+### Upload avatar / header
+
+```typescript
+const avatar = await client.uploadAvatar({ subname, file, onProgress });
+const header = await client.uploadHeader({ subname, file, onProgress });
+
+// avatar: AvatarUploadResult  ->  { url, avatarUrl, ... }
+// header: HeaderUploadResult  ->  { url, headerUrl, ... }
+```
+
+`uploadAvatar` returns `AvatarUploadResult` (with `avatarUrl`); `uploadHeader`
+returns `HeaderUploadResult` (with `headerUrl`). `url` is a stable alias the SDK
+normalizes to whichever of those the Metadata Service returned. The SDK validates
+that the returned URL is well-formed `http(s)`; if the service omits it or
+returns garbage it throws `API_ERROR` with status `502`.
+
+### Delete avatar / header
+
+```typescript
+await client.deleteAvatar({ subname });
+await client.deleteHeader({ subname });
+// -> { message, deletedAt }
+```
+
+## Manual flow (custom signing / server-side)
+
+For server-side usage or when you control signing yourself:
+
+```typescript
+const client = createAvatarClient({ network: 'mainnet', domain: 'yourapp.com' });
+
+// 1. Get the SIWE message (nonce fetched from the service for you)
+const siwe = await client.getSIWEMessageForAvatar({
+  address: '0x1234...',
+  // domain: optional, defaults to the configured domain
+  // chainId: optional, defaults to the network's chain id
+});
+// -> { message, nonce, expiresAt }
+
+// 2. Sign it yourself
+const signature = await wallet.signMessage(siwe.message);
+
+// 3. Submit with the pre-signed message
+const result = await client.uploadAvatarWithSignature({
+  subname: 'alice.namespace.eth',
+  file: avatarFile,
+  message: siwe.message,
+  signature,
+  address: '0x1234...',
+});
+```
+
+There are `avatar` and `header` variants of each manual method:
+`getSIWEMessageForHeader`, `uploadHeaderWithSignature`,
+`deleteAvatarWithSignature`, `deleteHeaderWithSignature`. The SIWE statement is
+`'Authorize a metadata update'`; nonce scope is `avatar` or `header`.
+
+## Wallet support
+
+Pass any of these directly as `provider` — the SDK detects and adapts them:
+
+- **Viem** `WalletClient` (reads `account.address`, `chain.id`, `signMessage`, and `switchChain` if present)
+- **Ethers** `Wallet` / `Signer` (v5 or v6 — `address` property or `getAddress()`)
+- **wagmi** `walletClient` from `useWalletClient()`
+- **A custom `WalletProvider`** object:
+
+```typescript
+const provider = {
+  getAddress: async () => '0x...',
+  signMessage: async (msg: string) => '0xsignature...',
+  getChainId: async () => 1,
+  switchChain: async (chainId: number) => { /* optional */ },
+};
+```
+
+`switchChain` is optional. If omitted and the wallet is on the wrong network,
+the SDK throws `PROVIDER_CHAIN_MISMATCH` instead of switching.
+
+## Configuration
+
+```typescript
+interface AvatarSDKConfig {
+  domain: string;                 // required — your app domain, used in SIWE
+  network?: 'mainnet' | 'sepolia';// default 'mainnet'
+  apiUrl?: string;                // default https://metadata.namespace.ninja
+  provider?: WalletProvider | any;// viem / ethers / WalletProvider
+}
+```
+
+Chain IDs: mainnet → `1`, sepolia → `11155111`. An explicit `chainId` passed to
+a manual message method must match the configured network or the Metadata
+Service rejects the mutation.
+
+## File constraints
+
+| Type   | Max size | Formats |
+|--------|----------|---------|
+| Avatar | 2 MB     | JPEG, PNG, GIF, WebP, SVG |
+| Header | 5 MB     | JPEG, PNG, GIF, WebP, SVG |
+
+```typescript
+import { AVATAR_MAX_SIZE, HEADER_MAX_SIZE, ALLOWED_FORMATS } from '@thenamespace/avatar';
+// ALLOWED_FORMATS = ['image/jpeg','image/jpg','image/png','image/gif','image/webp','image/svg+xml']
+```
+
+For `Buffer` inputs the SDK can only check size (no MIME type available), so
+format validation applies to browser `File` objects.
+
+## Metadata Service routes
+
+| Mutation | Route |
+|----------|-------|
+| Avatar upload/delete | `/profile/{network}/{subname}/avatar` |
+| Header upload/delete | `/profile/{network}/{subname}/h` |
+
+Header mutations use the **compact `/h` route**, but the multipart field name,
+SIWE nonce scope, and SIWE verification action remain `header`. Uploads send
+`siweMessage`, `siweSignature`, `address` plus the media file; deletes send the
+same three fields as JSON.
+
+## Error handling
+
+```typescript
+import { AvatarSDKError, ErrorCodes } from '@thenamespace/avatar';
+
+try {
+  await client.uploadAvatar({ subname, file });
+} catch (error) {
+  if (error instanceof AvatarSDKError) {
+    switch (error.code) {
+      case ErrorCodes.PROVIDER_CHAIN_MISMATCH:
+        // wallet on wrong network and can't be switched
+      case ErrorCodes.INVALID_SIGNATURE:
+      case ErrorCodes.NOT_SUBNAME_OWNER:
+      case ErrorCodes.EXPIRED_NONCE:
+      case ErrorCodes.FILE_TOO_LARGE:
+      case ErrorCodes.INVALID_FILE_FORMAT:
+      case ErrorCodes.MISSING_PROVIDER:
+      case ErrorCodes.UPLOAD_FAILED:
+      case ErrorCodes.DELETE_FAILED:
+      case ErrorCodes.NETWORK_ERROR:
+      case ErrorCodes.API_ERROR:
+        // error.status, error.serviceCode, error.details carry the service envelope
+    }
+  }
+}
+```
+
+Service failures are normalized to `AvatarSDKError` with code `API_ERROR`; the
+HTTP `status`, service `serviceCode`, and structured `details` are preserved on
+the error. Axios errors are sanitized so SIWE signatures in request bodies are
+not leaked through `originalError`.
+
+For the full type list and every export, see [reference.md](reference.md). For
+complete working examples (Viem, Ethers, React, manual flow, testnet), see
+[examples.md](examples.md).

--- a/.claude/skills/avatar-sdk/examples.md
+++ b/.claude/skills/avatar-sdk/examples.md
@@ -1,0 +1,427 @@
+# Avatar SDK Examples
+
+Complete working examples for `@thenamespace/avatar`.
+
+## Example 1: Basic Avatar Upload (Viem)
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { createWalletClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+import * as fs from 'fs';
+
+async function uploadAvatar() {
+  // Setup wallet
+  // Load secrets from your environment or secret manager; never hard-code them.
+  const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: mainnet,
+    transport: http()
+  });
+
+  // Initialize client
+  const client = createAvatarClient({
+    network: 'mainnet',
+    domain: 'myapp.com',
+    provider: walletClient
+  });
+
+  // Read file (Node.js)
+  const fileBuffer = fs.readFileSync('./avatar.png');
+
+  // Upload with progress tracking
+  const result = await client.uploadAvatar({
+    subname: 'alice.namespace.eth',
+    file: fileBuffer,
+    onProgress: (progress) => {
+      console.log(`Upload progress: ${progress.toFixed(1)}%`);
+    }
+  });
+
+  console.log('✓ Avatar uploaded!');
+  console.log(`  URL: ${result.url}`);
+  console.log(`  Size: ${result.fileSize} bytes`);
+  console.log(`  Uploaded at: ${result.uploadedAt}`);
+}
+
+uploadAvatar();
+```
+
+## Example 2: Browser File Upload
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { createWalletClient, custom } from 'viem';
+import { mainnet } from 'viem/chains';
+
+async function browserUpload(file: File) {
+  // Use browser wallet (MetaMask, etc.)
+  const walletClient = createWalletClient({
+    chain: mainnet,
+    transport: custom(window.ethereum)
+  });
+
+  const [address] = await walletClient.getAddresses();
+
+  const client = createAvatarClient({
+    network: 'mainnet',
+    domain: window.location.hostname,
+    provider: walletClient
+  });
+
+  // Validate file before upload (avatar max is 2MB; header max is 5MB)
+  const AVATAR_MAX = 2 * 1024 * 1024;
+  if (file.size > AVATAR_MAX) {
+    throw new Error(`File too large (max ${AVATAR_MAX / (1024 * 1024)}MB)`);
+  }
+
+  const allowed = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'];
+  if (!allowed.includes(file.type)) {
+    throw new Error('Invalid file type');
+  }
+
+  // Upload
+  const result = await client.uploadAvatar({
+    subname: 'myname.namespace.eth',
+    file: file,
+    onProgress: (progress) => {
+      document.getElementById('progress')!.textContent = `${progress.toFixed(0)}%`;
+    }
+  });
+
+  return result.url;
+}
+
+// Usage with file input
+document.getElementById('fileInput')?.addEventListener('change', async (e) => {
+  const file = (e.target as HTMLInputElement).files?.[0];
+  if (file) {
+    const url = await browserUpload(file);
+    console.log('Uploaded:', url);
+  }
+});
+```
+
+## Example 3: Upload Header Image
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { createWalletClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+async function uploadHeader() {
+  const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: mainnet,
+    transport: http()
+  });
+
+  const client = createAvatarClient({
+    network: 'mainnet',
+    domain: 'myapp.com',
+    provider: walletClient
+  });
+
+  // Upload header (typically larger/wider image)
+  const result = await client.uploadHeader({
+    subname: 'alice.namespace.eth',
+    file: headerBuffer,
+    onProgress: (p) => console.log(`Header upload: ${p}%`)
+  });
+
+  console.log('Header URL:', result.url);
+}
+```
+
+## Example 4: Manual SIWE Flow (Server-Side)
+
+For server-side applications or when you need custom signing:
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { Wallet } from 'ethers';
+
+async function manualSIWEFlow() {
+  // Client without provider (manual mode)
+  const client = createAvatarClient({
+    network: 'sepolia',
+    domain: 'api.myapp.com'
+  });
+
+  const wallet = new Wallet(process.env.PRIVATE_KEY!);
+  const address = await wallet.getAddress();
+
+  // Step 1: Get SIWE message
+  console.log('Getting SIWE message...');
+  const siweResult = await client.getSIWEMessageForAvatar({
+    address: address,
+    // chainId omitted: resolves from configured Sepolia network (11155111)
+  });
+
+  // Never log the SIWE message or signature.
+  console.log('SIWE message prepared');
+  console.log('Expires:', new Date(siweResult.expiresAt).toISOString());
+
+  // Step 2: Sign the message
+  console.log('Signing message...');
+  const signature = await wallet.signMessage(siweResult.message);
+
+  // Step 3: Upload with signature
+  console.log('Uploading avatar...');
+  const result = await client.uploadAvatarWithSignature({
+    subname: 'test.namespace.eth',
+    file: avatarBuffer,
+    message: siweResult.message,
+    signature: signature,
+    address: address,
+    onProgress: (p) => console.log(`${p}%`)
+  });
+
+  console.log('✓ Uploaded:', result.url);
+}
+```
+
+## Example 5: Delete Avatar and Header
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { createWalletClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+async function deleteImages() {
+  const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: mainnet,
+    transport: http()
+  });
+
+  const client = createAvatarClient({
+    network: 'mainnet',
+    domain: 'myapp.com',
+    provider: walletClient
+  });
+
+  const subname = 'alice.namespace.eth';
+
+  // Delete avatar
+  const avatarResult = await client.deleteAvatar({ subname });
+  console.log(`Avatar deleted at: ${avatarResult.deletedAt}`);
+
+  // Delete header
+  const headerResult = await client.deleteHeader({ subname });
+  console.log(`Header deleted at: ${headerResult.deletedAt}`);
+}
+```
+
+## Example 6: Error Handling
+
+```typescript
+import { createAvatarClient, AvatarSDKError, ErrorCodes } from '@thenamespace/avatar';
+
+async function uploadWithErrorHandling() {
+  const client = createAvatarClient({
+    network: 'mainnet',
+    domain: 'myapp.com',
+    provider: walletClient
+  });
+
+  try {
+    const result = await client.uploadAvatar({
+      subname: 'alice.namespace.eth',
+      file: avatarFile
+    });
+    console.log('Success:', result.url);
+  } catch (error) {
+    if (error instanceof AvatarSDKError) {
+      console.error(`Error [${error.code}]: ${error.message}`);
+
+      switch (error.code) {
+        case ErrorCodes.NOT_SUBNAME_OWNER:
+          console.error('You must own this subname to upload images');
+          break;
+        case ErrorCodes.PROVIDER_CHAIN_MISMATCH:
+          console.error('Wallet is on the wrong network — switch to the configured chain');
+          break;
+        case ErrorCodes.EXPIRED_NONCE:
+          console.error('Session expired, please try again');
+          break;
+        case ErrorCodes.FILE_TOO_LARGE:
+          console.error('Please use a smaller image (avatar ≤ 2MB, header ≤ 5MB)');
+          break;
+        case ErrorCodes.INVALID_FILE_FORMAT:
+        case ErrorCodes.INVALID_FILE_TYPE:
+          console.error('Please use JPEG, PNG, GIF, WebP, or SVG');
+          break;
+        case ErrorCodes.MISSING_PROVIDER:
+          console.error('Wallet provider required for automatic signing');
+          break;
+        case ErrorCodes.API_ERROR:
+          console.error(`Service error ${error.status}: ${error.message}`, error.details);
+          break;
+        default:
+          console.error('Upload failed, please try again');
+      }
+    } else {
+      console.error('Unexpected error:', error);
+    }
+  }
+}
+```
+
+## Example 7: Testnet (Sepolia) Upload
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+import { createWalletClient, http } from 'viem';
+import { sepolia } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+async function testnetUpload() {
+  const account = privateKeyToAccount(process.env.SEPOLIA_PRIVATE_KEY as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: sepolia,
+    transport: http()
+  });
+
+  // Use sepolia network
+  const client = createAvatarClient({
+    network: 'sepolia',
+    domain: 'test.myapp.com',
+    provider: walletClient
+  });
+
+  const result = await client.uploadAvatar({
+    subname: 'test.namespace.eth',
+    file: testAvatar
+  });
+
+  console.log('Testnet avatar URL:', result.url);
+}
+```
+
+## Example 8: Upload Both Avatar and Header
+
+```typescript
+import { createAvatarClient } from '@thenamespace/avatar';
+
+async function uploadProfileImages(
+  avatarFile: File | Buffer,
+  headerFile: File | Buffer,
+  subname: string
+) {
+  const client = createAvatarClient({
+    network: 'mainnet',
+    domain: 'myapp.com',
+    provider: walletClient
+  });
+
+  console.log(`Uploading profile images for ${subname}...`);
+
+  // Upload avatar
+  const avatarResult = await client.uploadAvatar({
+    subname,
+    file: avatarFile,
+    onProgress: (p) => console.log(`Avatar: ${p.toFixed(0)}%`)
+  });
+
+  // Upload header
+  const headerResult = await client.uploadHeader({
+    subname,
+    file: headerFile,
+    onProgress: (p) => console.log(`Header: ${p.toFixed(0)}%`)
+  });
+
+  return {
+    avatar: avatarResult.url,
+    header: headerResult.url
+  };
+}
+```
+
+## Example 9: Custom Wallet Provider
+
+```typescript
+import { createAvatarClient, WalletProvider } from '@thenamespace/avatar';
+
+// Custom provider (e.g., for hardware wallets)
+const customProvider: WalletProvider = {
+  getAddress: async () => {
+    // Return address from your custom wallet
+    return '0x1234567890123456789012345678901234567890';
+  },
+  signMessage: async (message: string) => {
+    // Sign with your custom wallet
+    const signature = await myHardwareWallet.sign(message);
+    return signature;
+  },
+  getChainId: async () => {
+    return 1; // Mainnet
+  },
+  // Optional: lets the SDK switch chains automatically instead of
+  // throwing PROVIDER_CHAIN_MISMATCH when the wallet is on the wrong network.
+  switchChain: async (chainId: number) => {
+    await myHardwareWallet.switchChain(chainId);
+  }
+};
+
+const client = createAvatarClient({
+  network: 'mainnet',
+  domain: 'myapp.com',
+  provider: customProvider
+});
+
+// Use normally
+const result = await client.uploadAvatar({
+  subname: 'secure.namespace.eth',
+  file: avatarFile
+});
+```
+
+## Example 10: Smart-contract wallet + normalized result (v2)
+
+SIWE v4 accepts signatures from deployed smart-contract wallets (Safe,
+account-abstraction signers, etc.) with no extra wiring — the SDK forwards the
+signature to the Metadata Service, which verifies it on-chain. Just pass the
+wallet's signer as the `provider` like any other wallet.
+
+```typescript
+import { createAvatarClient, AvatarUploadResult, HeaderUploadResult } from '@thenamespace/avatar';
+
+// `signer` here is whatever your smart-contract wallet exposes for SIWE
+// signing (for example, a signer for a deployed Safe or contract wallet).
+const client = createAvatarClient({
+  network: 'mainnet',
+  domain: 'myapp.com',
+  provider: signer,
+});
+
+const avatar: AvatarUploadResult = await client.uploadAvatar({
+  subname: 'alice.namespace.eth',
+  file: avatarFile,
+});
+
+// v2 result: `url` is a stable alias; the canonical field is also exposed.
+console.log(avatar.url);        // stable public URL
+console.log(avatar.avatarUrl);  // same value, canonical avatar URL
+
+const header: HeaderUploadResult = await client.uploadHeader({
+  subname: 'alice.namespace.eth',
+  file: headerFile,
+});
+
+console.log(header.url);        // stable public URL
+console.log(header.headerUrl);  // canonical header URL (compact /h route)
+```
+
+Before each automatic upload/delete, the SDK checks `signer.getChainId()`
+against the configured network and calls `signer.switchChain()` if available —
+so smart-contract wallets on the wrong chain fail fast with
+`PROVIDER_CHAIN_MISMATCH` rather than producing a signature the service will
+reject.

--- a/.claude/skills/avatar-sdk/reference.md
+++ b/.claude/skills/avatar-sdk/reference.md
@@ -1,0 +1,298 @@
+# Avatar SDK API Reference (v2)
+
+Type definitions and exports for `@thenamespace/avatar`.
+
+## Exports
+
+```typescript
+import {
+  // Main factory + client
+  createAvatarClient,
+  AvatarClient,
+
+  // Config + wallet types
+  AvatarSDKConfig,
+  WalletProvider,
+
+  // Upload / delete types
+  UploadOptions,
+  UploadResult,
+  AvatarUploadResult,
+  HeaderUploadResult,
+  DeleteOptions,
+  DeleteResult,
+
+  // SIWE types
+  SIWEMessageOptions,
+  SIWEMessageResult,
+  UploadWithSignatureOptions,
+  DeleteWithSignatureOptions,
+  NonceRequest,
+  NonceResponse,
+
+  // Error handling
+  AvatarSDKError,
+  ErrorCodes,
+  createError,
+
+  // Validation utilities
+  validateFile,
+  validateSubname,
+  validateAddress,
+  validateSIWEOptionsResolved,
+  AVATAR_MAX_SIZE,
+  HEADER_MAX_SIZE,
+  ALLOWED_FORMATS,
+
+  // SIWE utilities
+  generateSIWEMessage,
+  createAvatarNonceRequest,
+  createHeaderNonceRequest,
+  createCombinedNonceRequest,
+  isNonceExpired,
+  getDefaultChainId,
+
+  // Wallet adapter (advanced)
+  adaptWallet,
+} from '@thenamespace/avatar';
+```
+
+## AvatarSDKConfig
+
+```typescript
+interface AvatarSDKConfig {
+  /** API URL for the avatar service (defaults to production) */
+  apiUrl?: string;
+  /** Network: 'mainnet' (default) or 'sepolia' */
+  network?: 'mainnet' | 'sepolia';
+  /** Your app domain — required for SIWE authentication */
+  domain: string;
+  /** Wallet provider: Viem WalletClient, Ethers Wallet/Signer, or WalletProvider */
+  provider?: WalletProvider | any;
+}
+```
+
+## WalletProvider
+
+```typescript
+interface WalletProvider {
+  getAddress(): Promise<string>;
+  signMessage(message: string): Promise<string>;
+  getChainId(): Promise<number>;
+  /** Optional — if present, the SDK will try to switch the wallet to the
+   *  configured network before raising PROVIDER_CHAIN_MISMATCH. */
+  switchChain?(chainId: number): Promise<void>;
+}
+```
+
+## AvatarClient
+
+```typescript
+interface AvatarClient {
+  // Automatic flow (requires provider)
+  uploadAvatar(options: UploadOptions): Promise<AvatarUploadResult>;
+  uploadHeader(options: UploadOptions): Promise<HeaderUploadResult>;
+  deleteAvatar(options: DeleteOptions): Promise<DeleteResult>;
+  deleteHeader(options: DeleteOptions): Promise<DeleteResult>;
+
+  // Manual flow (custom / server-side signing)
+  getSIWEMessageForAvatar(options: SIWEMessageOptions): Promise<SIWEMessageResult>;
+  getSIWEMessageForHeader(options: SIWEMessageOptions): Promise<SIWEMessageResult>;
+  uploadAvatarWithSignature(options: UploadWithSignatureOptions): Promise<AvatarUploadResult>;
+  uploadHeaderWithSignature(options: UploadWithSignatureOptions): Promise<HeaderUploadResult>;
+  deleteAvatarWithSignature(options: DeleteWithSignatureOptions): Promise<DeleteResult>;
+  deleteHeaderWithSignature(options: DeleteWithSignatureOptions): Promise<DeleteResult>;
+}
+```
+
+## Upload types
+
+### UploadOptions
+
+```typescript
+interface UploadOptions {
+  /** ENS subname (e.g. 'alice.namespace.eth') */
+  subname: string;
+  /** Browser File or Node.js Buffer */
+  file: File | Buffer;
+  /** Upload progress callback (0–100) */
+  onProgress?: (progress: number) => void;
+}
+```
+
+### UploadResult
+
+```typescript
+interface UploadResult {
+  /** Stable SDK alias — normalized from avatarUrl / headerUrl */
+  url: string;
+  /** Avatar URL returned by the Metadata Service (avatar uploads) */
+  avatarUrl?: string;
+  /** Compact header URL returned by the Metadata Service (header uploads) */
+  headerUrl?: string;
+  /** Subname echoed back by the service */
+  subname?: string;
+  /** Network echoed back by the service */
+  network?: 'mainnet' | 'sepolia';
+  /** Upload timestamp (ISO 8601) */
+  uploadedAt: string;
+  /** File size in bytes */
+  fileSize: number;
+  /** Whether this updated an existing image */
+  isUpdate: boolean;
+  /** Whether the upload is pending (unregistered names) */
+  pending?: boolean;
+  /** Optional server message */
+  message?: string;
+}
+
+interface AvatarUploadResult extends UploadResult {
+  avatarUrl: string; // canonical public avatar URL
+}
+
+interface HeaderUploadResult extends UploadResult {
+  headerUrl: string; // canonical public header URL
+}
+```
+
+The SDK validates the returned `avatarUrl`/`headerUrl` is a well-formed
+`http(s)` URL. If the service omits it or returns an invalid URL, it throws
+`AvatarSDKError` with code `API_ERROR` and status `502`.
+
+## Delete types
+
+```typescript
+interface DeleteOptions {
+  subname: string;
+}
+
+interface DeleteResult {
+  message: string;
+  deletedAt: string; // ISO 8601
+}
+```
+
+## SIWE types
+
+```typescript
+interface SIWEMessageOptions {
+  address: string;
+  /** Optional — defaults to the configured domain */
+  domain?: string;
+  /** Optional — defaults to https://{domain} */
+  uri?: string;
+  /** Optional — defaults to the network's chain id (1 / 11155111) */
+  chainId?: number;
+}
+
+interface SIWEMessageResult {
+  message: string;   // the SIWE message to sign
+  nonce: string;
+  expiresAt: number; // Unix ms
+}
+
+interface UploadWithSignatureOptions extends UploadOptions {
+  message: string;
+  signature: string;
+  address: string;
+}
+
+interface DeleteWithSignatureOptions extends DeleteOptions {
+  message: string;
+  signature: string;
+  address: string;
+}
+```
+
+The SIWE statement is `'Authorize a metadata update'`; the message is built with
+`@signinwithethereum/siwe` v4. Signatures from EOAs *and* deployed smart-contract
+wallets are accepted — the SDK does no client-side ERC-6492 handling; it forwards
+the signature to the Metadata Service for verification.
+
+## Nonce types
+
+```typescript
+interface NonceRequest {
+  address: string;
+  scope: 'avatar' | 'header' | 'avatar+header';
+}
+
+interface NonceResponse {
+  nonce: string;
+  expiresAt: number; // Unix ms
+}
+```
+
+## Error codes
+
+```typescript
+const ErrorCodes = {
+  // File validation
+  FILE_TOO_LARGE: 'FILE_TOO_LARGE',
+  INVALID_FILE_FORMAT: 'INVALID_FILE_FORMAT',
+  INVALID_FILE_TYPE: 'INVALID_FILE_TYPE',
+
+  // Authentication
+  INVALID_SIGNATURE: 'INVALID_SIGNATURE',
+  EXPIRED_NONCE: 'EXPIRED_NONCE',
+  INVALID_NONCE: 'INVALID_NONCE',
+  AUTHENTICATION_FAILED: 'AUTHENTICATION_FAILED',
+
+  // ENS
+  NOT_SUBNAME_OWNER: 'NOT_SUBNAME_OWNER',
+  INVALID_SUBNAME: 'INVALID_SUBNAME',
+  SUBNAME_NOT_FOUND: 'SUBNAME_NOT_FOUND',
+
+  // Network
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT_ERROR: 'TIMEOUT_ERROR',
+  API_ERROR: 'API_ERROR',
+
+  // Provider
+  PROVIDER_NOT_CONNECTED: 'PROVIDER_NOT_CONNECTED',
+  PROVIDER_ERROR: 'PROVIDER_ERROR',
+  PROVIDER_CHAIN_MISMATCH: 'PROVIDER_CHAIN_MISMATCH',
+
+  // Configuration
+  INVALID_CONFIG: 'INVALID_CONFIG',
+  MISSING_PROVIDER: 'MISSING_PROVIDER',
+
+  // Operations
+  UPLOAD_FAILED: 'UPLOAD_FAILED',
+  DELETE_FAILED: 'DELETE_FAILED',
+} as const;
+```
+
+`AvatarSDKError` exposes `code`, `status?`, `serviceCode?`, `details?`, and
+`originalError?`. Metadata Service failures are normalized to code `API_ERROR`
+with the HTTP status and structured service envelope preserved on `status` /
+`serviceCode` / `details`. Request-body signatures are stripped from
+`originalError` so they aren't leaked.
+
+## Constants
+
+```typescript
+const AVATAR_MAX_SIZE = 2 * 1024 * 1024;  // 2 MB
+const HEADER_MAX_SIZE = 5 * 1024 * 1024;  // 5 MB
+const ALLOWED_FORMATS = [
+  'image/jpeg', 'image/jpg', 'image/png',
+  'image/gif', 'image/webp', 'image/svg+xml',
+];
+```
+
+`getDefaultChainId('mainnet')` → `1`; `getDefaultChainId('sepolia')` → `11155111`.
+
+## API endpoints
+
+Base URL (both networks): `https://metadata.namespace.ninja`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/auth/nonce` | POST | Get SIWE nonce (body: `{ address, scope }`) |
+| `/profile/{network}/{subname}/avatar` | POST | Upload avatar (multipart) |
+| `/profile/{network}/{subname}/avatar` | DELETE | Delete avatar (JSON) |
+| `/profile/{network}/{subname}/h` | POST | Upload header (multipart, field name `header`) |
+| `/profile/{network}/{subname}/h` | DELETE | Delete header (JSON) |
+
+Header mutations use the compact `/h` route; the multipart field name, SIWE nonce
+scope, and SIWE verification action remain `header`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -57,7 +50,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3355,7 +3347,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4109,13 +4100,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4610,7 +4594,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5787,6 +5770,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5938,85 +5946,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ethers": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
-      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/ethers/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/ethers/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/ethers/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -7652,7 +7581,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9708,7 +9636,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -11856,7 +11783,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12145,7 +12071,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12415,7 +12340,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",


### PR DESCRIPTION
## Summary

- Regenerates the root `package-lock.json` with npm 11.
- Adds the reviewed Avatar SDK skill under `.claude/skills/avatar-sdk`.
- Documents SIWE v4, network enforcement, `/h` header operations, normalized URLs, and errors.
- Hardens examples against secret and SIWE-message leakage.

## Verification

- Clean npm 11 install passed.
- Avatar SDK build passed.
- All 187 Avatar SDK tests passed.
- Skill structure, frontmatter, references, and formatting validated.

## Scope

This PR only contains the lockfile correction and Avatar SDK skill. The SIWE v4 SDK implementation was merged previously.

## Known caveat

The existing upstream Axios audit advisory remains outside this PR’s scope.
