### PR TITLE
fix(avatar): use /header mutation endpoint

### DIFF
--- a/.claude/skills/avatar-sdk/SKILL.md
+++ b/.claude/skills/avatar-sdk/SKILL.md
@@ -181,12 +181,13 @@ format validation applies to browser `File` objects.
 | Mutation | Route |
 |----------|-------|
 | Avatar upload/delete | `/profile/{network}/{subname}/avatar` |
-| Header upload/delete | `/profile/{network}/{subname}/h` |
+| Header upload/delete | `/profile/{network}/{subname}/header` |
 
-Header mutations use the **compact `/h` route**, but the multipart field name,
-SIWE nonce scope, and SIWE verification action remain `header`. Uploads send
-`siweMessage`, `siweSignature`, `address` plus the media file; deletes send the
-same three fields as JSON.
+Header mutations use `/header`. The stable public header URL returned in
+`headerUrl` uses the compact `/h` path. The multipart field name, SIWE nonce
+scope, and SIWE verification action remain `header`. Uploads send `siweMessage`,
+`siweSignature`, `address` plus the media file; deletes send the same three
+fields as JSON.
 
 ## Error handling
 

--- a/.claude/skills/avatar-sdk/examples.md
+++ b/.claude/skills/avatar-sdk/examples.md
@@ -417,7 +417,7 @@ const header: HeaderUploadResult = await client.uploadHeader({
 });
 
 console.log(header.url);        // stable public URL
-console.log(header.headerUrl);  // canonical header URL (compact /h route)
+console.log(header.headerUrl);  // canonical public URL (uses the compact /h path)
 ```
 
 Before each automatic upload/delete, the SDK checks `signer.getChainId()`

--- a/.claude/skills/avatar-sdk/reference.md
+++ b/.claude/skills/avatar-sdk/reference.md
@@ -128,7 +128,7 @@ interface UploadResult {
   url: string;
   /** Avatar URL returned by the Metadata Service (avatar uploads) */
   avatarUrl?: string;
-  /** Compact header URL returned by the Metadata Service (header uploads) */
+  /** Stable public header URL returned by the Metadata Service (uses `/h`) */
   headerUrl?: string;
   /** Subname echoed back by the service */
   subname?: string;
@@ -291,8 +291,9 @@ Base URL (both networks): `https://metadata.namespace.ninja`
 | `/auth/nonce` | POST | Get SIWE nonce (body: `{ address, scope }`) |
 | `/profile/{network}/{subname}/avatar` | POST | Upload avatar (multipart) |
 | `/profile/{network}/{subname}/avatar` | DELETE | Delete avatar (JSON) |
-| `/profile/{network}/{subname}/h` | POST | Upload header (multipart, field name `header`) |
-| `/profile/{network}/{subname}/h` | DELETE | Delete header (JSON) |
+| `/profile/{network}/{subname}/header` | POST | Upload header (multipart, field name `header`) |
+| `/profile/{network}/{subname}/header` | DELETE | Delete header (JSON) |
 
-Header mutations use the compact `/h` route; the multipart field name, SIWE nonce
-scope, and SIWE verification action remain `header`.
+Header mutations use `/header`; the stable public URL returned in `headerUrl`
+uses `/h`. The multipart field name, SIWE nonce scope, and SIWE verification
+action remain `header`.

--- a/README.md
+++ b/README.md
@@ -3,79 +3,93 @@
   <img alt="Namespace" src="https://raw.githubusercontent.com/thenamespace/namespacesdk/release/assets/namespace-logo-dark.png" width="320">
 </picture>
 
-TypeScript SDKs on Namespace API. Mint, manage & query offchain and onchain ENS subnames.
+# Namespace SDK
 
-# Namespace SDK Monorepo
+TypeScript SDKs for building with Namespace and ENS. Mint and manage subnames,
+query indexed data, resolve deployed contract addresses, and manage ENS profile
+images.
 
-This monorepo contains TypeScript SDK packages for interacting with the Namespace ecosystem. It's built using [Lerna](https://lerna.js.org/) for managing multiple packages.
+## Packages
 
-## 📦 Packages
+| Package | Use it to |
+| --- | --- |
+| [`@thenamespace/addresses`](./packages/addresses) | Look up Namespace and ENS contract addresses by chain. |
+| [`@thenamespace/avatar`](./packages/avatar) | Upload and delete ENS avatar and header images using SIWE authentication. |
+| [`@thenamespace/indexer`](./packages/indexer) | Query L2 subnames, registries, and metadata through the Namespace Indexer API. |
+| [`@thenamespace/mint-manager`](./packages/mint-manager) | Check availability and mint ENS subnames on Mainnet and supported L2 networks. |
+| [`@thenamespace/offchain-manager`](./packages/offchain-manager) | Create, update, query, and delete gasless offchain ENS subnames and records. |
 
-This monorepo contains the following SDK packages:
+Each package is published independently on npm and has its own installation,
+API, and usage documentation.
 
-### [@thenamespace/addresses](./packages/addresses)
+## Installation
 
-Library containing all Namespace & ENS contract addresses.
+Install only the package your application needs:
 
-### [@thenamespace/indexer](./packages/indexer)
+```sh
+npm install @thenamespace/offchain-manager
+```
 
-TypeScript SDK for interacting with the Namespace Indexer API - query L2 subnames, registries, and metadata.
+Replace `@thenamespace/offchain-manager` with any package listed above.
 
-### [@thenamespace/mint-manager](./packages/mint-manager)
+## Work on the monorepo
 
-Library for minting L2 subnames with comprehensive validation and error handling.
+### Requirements
 
-### [@thenamespace/offchain-manager](./packages/offchain-manager)
-
-TypeScript SDK for creating and managing ENS subnames off-chain with the Namespace API.
-
-## 🚀 Getting Started
-
-### Prerequisites
-
-- Node.js >= 16.0.0
+- Node.js 16 or newer
 - npm
 
-### Installation
+### Setup
 
-```bash
-# Clone the repository
+```sh
 git clone https://github.com/thenamespace/namespacesdk.git
 cd namespacesdk
-
-# Install dependencies for all packages
 npm install
-
 ```
 
-## 📁 Project Structure
+The repository uses npm workspaces and Lerna. Run package scripts from the
+repository root with npm's `--workspace` option:
 
+```sh
+# Build one package
+npm run build --workspace=@thenamespace/avatar
+
+# Run the Avatar SDK unit tests
+npm test --workspace=@thenamespace/avatar
+
+# Type-check the Avatar SDK
+npm run type-check --workspace=@thenamespace/avatar
 ```
+
+Available scripts differ by package; check the relevant package's
+`package.json` before running a command.
+
+## Repository structure
+
+```text
 namespacesdk/
 ├── packages/
-│   ├── addresses/          # Contract addresses library
-│   ├── indexer/           # Indexer API SDK
-│   ├── mint-manager/      # L2 subname minting library
-│   └── offchain-manager/  # Off-chain subname management SDK
-├── lerna.json            # Lerna configuration
-└── package.json          # Root package.json (monorepo config)
+│   ├── addresses/          # Namespace and ENS contract addresses
+│   ├── avatar/             # ENS avatar and header image management
+│   ├── indexer/            # Namespace Indexer API client
+│   ├── mint-manager/       # ENS subname availability and minting
+│   └── offchain-manager/   # Gasless offchain subname management
+├── changelog/              # Package release history and release notes
+├── lerna.json
+└── package.json
 ```
 
-## 🤝 Contributing
+## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Add tests if applicable
-5. Run `npm run test` to ensure all tests pass
-6. Submit a pull request
+Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) for the
+development workflow, package-specific checks, and pull request guidelines.
 
-## 📄 License
+## Resources
 
-This project is licensed under the MIT License.
-
-## 🔗 Links
-
-- [Namespace Website](https://namespace.ninja)
+- [Namespace](https://namespace.ninja)
 - [Documentation](https://docs.namespace.ninja)
-- [GitHub Issues](https://github.com/thenamespace/namespacesdk/issues)
+- [GitHub issues](https://github.com/thenamespace/namespacesdk/issues)
+
+## License
+
+Licensed under the MIT License.

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -235,9 +235,11 @@ it throws `PROVIDER_CHAIN_MISMATCH` before requesting or signing a SIWE message.
 ### Metadata Service routes
 
 Avatar mutations use
-`/profile/{network}/{subname}/avatar`. Header mutations use the compact
-`/profile/{network}/{subname}/h` endpoint. Header nonce scopes and multipart
-field names remain `header`.
+`/profile/{network}/{subname}/avatar`. Header mutations use
+`/profile/{network}/{subname}/header`. The stable public header URL returned in
+`headerUrl` uses the compact `/h` path (for example,
+`https://avtr.cc/alice.eth/h`). Header nonce scopes and multipart field names
+remain `header`.
 
 Authenticated uploads send `siweMessage`, `siweSignature`, and `address`
 alongside the media file. Deletes send the same three fields as JSON.

--- a/packages/avatar/src/core/client.ts
+++ b/packages/avatar/src/core/client.ts
@@ -449,11 +449,13 @@ class HttpAvatarClient implements AvatarClient {
   }
 
   /**
-   * Header media mutations use the compact `/h` route. The multipart field,
-   * SIWE nonce scope, and SIWE verification action remain `header`.
+   * Header media mutations use `/header`. The compact `/h` path is reserved
+   * for the stable public header URL returned by the Metadata Service. The
+   * multipart field, SIWE nonce scope, and verification action remain
+   * `header`.
    */
   private getMutationPath(subname: string, type: 'avatar' | 'header'): string {
-    const mediaPath = type === 'header' ? 'h' : 'avatar';
+    const mediaPath = type === 'header' ? 'header' : 'avatar';
     return `/profile/${this.config.network}/${subname}/${mediaPath}`;
   }
 
@@ -518,13 +520,14 @@ class HttpAvatarClient implements AvatarClient {
   }
 
   private async uploadWithProgress(
-    url: string,
+    path: string,
     formData: FormData,
     onProgress?: (progress: number) => void
   ): Promise<any> {
     try {
-      // Use axios for better Node.js compatibility
-      const response = await this.http.post(`${this.config.apiUrl}${url}`, formData, {
+      // The Axios instance owns the API origin through baseURL. Keep the
+      // mutation path relative so upload and delete share the same routing.
+      const response = await this.http.post(path, formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
         },

--- a/packages/avatar/src/core/types.ts
+++ b/packages/avatar/src/core/types.ts
@@ -47,7 +47,7 @@ export interface UploadResult {
   url: string;
   /** Avatar URL returned by the Metadata Service for avatar uploads */
   avatarUrl?: string;
-  /** Compact header URL returned by the Metadata Service for header uploads */
+  /** Stable public header URL returned by the Metadata Service (uses `/h`) */
   headerUrl?: string;
   /** ENS subname returned by the Metadata Service */
   subname?: string;

--- a/packages/avatar/tests/client.test.ts
+++ b/packages/avatar/tests/client.test.ts
@@ -205,7 +205,7 @@ describe('AvatarClient', () => {
       address: '0x54b06711C8022faf11EC347F2bDc68A91eA03a3a'
     };
 
-    it('should upload headers through the compact /h endpoint', async () => {
+    it('should upload headers through /header while keeping the header multipart field', async () => {
       mockAxiosInstance.post.mockResolvedValue({
         data: {
           headerUrl: 'https://avtr.cc/test.eth/h',
@@ -221,15 +221,18 @@ describe('AvatarClient', () => {
       });
 
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
-        'https://test-api.example.com/profile/mainnet/test.eth/h',
+        '/profile/mainnet/test.eth/header',
         expect.any(FormData),
         expect.any(Object)
       );
+      const formData = mockAxiosInstance.post.mock.calls[0][1] as FormData;
+      expect(formData.get('header')).toBeInstanceOf(File);
+      expect(formData.has('h')).toBe(false);
       expect(result.url).toBe('https://avtr.cc/test.eth/h');
       expect(result.headerUrl).toBe('https://avtr.cc/test.eth/h');
     });
 
-    it('should delete headers through the compact /h endpoint', async () => {
+    it('should delete headers through the /header endpoint', async () => {
       mockAxiosInstance.delete.mockResolvedValue({
         data: {
           message: 'Header deleted successfully',
@@ -240,7 +243,7 @@ describe('AvatarClient', () => {
       await client.deleteHeaderWithSignature(signedRequest);
 
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
-        '/profile/mainnet/test.eth/h',
+        '/profile/mainnet/test.eth/header',
         {
           data: {
             siweMessage: signedRequest.message,
@@ -265,6 +268,45 @@ describe('AvatarClient', () => {
         '/profile/mainnet/test.eth/avatar',
         expect.any(Object)
       );
+    });
+
+    it('should prefer canonical headerUrl over the compatibility url field', async () => {
+      mockAxiosInstance.post.mockResolvedValue({
+        data: {
+          headerUrl: 'https://avtr.cc/test.eth/h',
+          url: 'https://legacy.example.com/test.eth/header.jpg',
+          uploadedAt: new Date().toISOString(),
+          fileSize: 1024,
+          isUpdate: false
+        }
+      });
+
+      const result = await client.uploadHeaderWithSignature({
+        ...signedRequest,
+        file: new File(['header'], 'header.jpg', { type: 'image/jpeg' })
+      });
+
+      expect(result.headerUrl).toBe('https://avtr.cc/test.eth/h');
+      expect(result.url).toBe('https://avtr.cc/test.eth/h');
+    });
+
+    it('should accept url as a compatibility fallback for header uploads', async () => {
+      mockAxiosInstance.post.mockResolvedValue({
+        data: {
+          url: 'https://legacy.example.com/test.eth/header.jpg',
+          uploadedAt: new Date().toISOString(),
+          fileSize: 1024,
+          isUpdate: false
+        }
+      });
+
+      const result = await client.uploadHeaderWithSignature({
+        ...signedRequest,
+        file: new File(['header'], 'header.jpg', { type: 'image/jpeg' })
+      });
+
+      expect(result.headerUrl).toBe('https://legacy.example.com/test.eth/header.jpg');
+      expect(result.url).toBe('https://legacy.example.com/test.eth/header.jpg');
     });
 
     it('should reject unsafe media URL schemes returned by the service', async () => {


### PR DESCRIPTION
## Summary

- route Avatar SDK header uploads and deletes to the deployed `/profile/{network}/{subname}/header` mutation endpoint
- use the Axios instance `baseURL` consistently for upload and delete requests
- keep the multipart field and SIWE scope as `header`
- preserve canonical `headerUrl` handling with legacy `url` as a compatibility fallback
- distinguish the `/header` mutation endpoint from the stable public `/h` media URL in SDK documentation
- improve the monorepo README with the complete package list and valid workspace commands

## Root cause

`@thenamespace/avatar@2.0.0` unintentionally mapped header mutations to the
compact `/h` segment. This was a bug, not a contract change. The Metadata
Service exposes POST and DELETE header mutations at `/header`; `/h` remains the
path used by the stable public header URL returned in `headerUrl`.

## Release note for the next version

The published `2.0.0` changelog remains unchanged. Use this entry for the next
Avatar SDK release:

### Fixed

- Fixed an unintended regression introduced in `2.0.0` that sent header upload
  and deletion requests to the public `/h` route instead of the Metadata
  Service mutation endpoint.
- Restored header mutations to
  `/profile/{network}/{subname}/header`.
- Kept the multipart field name and SIWE resource scope as `header`.
- Continued treating `headerUrl` as the canonical response field while
  accepting `url` as a compatibility fallback.
- The stable public header image URL remains `/h`; only mutation requests use
  `/header`.

## Compatibility and security

- no public method or type is removed
- `headerUrl` remains canonical and `url` remains a fallback alias
- avatar mutations remain on `/avatar`
- SIWE message, signature, address fields, nonce scope, and chain behavior are unchanged
- authenticated requests remain confined to the configured Axios origin
- error sanitization behavior is unchanged

## Verification

The Avatar SDK code was verified before the README-only follow-up commit:

- `npm ci --ignore-scripts=false`
- `npm test --workspace=@thenamespace/avatar -- --runInBand` — 189 tests passed
- `npm run type-check --workspace=@thenamespace/avatar`
- `npm run build --workspace=@thenamespace/avatar`
- `npm pack --workspace=@thenamespace/avatar --dry-run` — 30 expected package files
- `git diff --check`

## Known repository-level findings

- `npm run lint --workspace=@thenamespace/avatar` cannot run because the workspace does not currently install/configure `eslint` (`eslint: command not found`).
- The clean install reports existing dependency audit findings: 39 total (2 low, 6 moderate, 29 high, 2 critical). This PR does not change dependencies or the lockfile.

No npm publication, tag, release action, or historical changelog rewrite is
included.
